### PR TITLE
Feat(#20) Task 상세 화면 구현

### DIFF
--- a/app/src/main/java/flab/eryuksa/todocompose/data/database/TaskDatabase.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/data/database/TaskDatabase.kt
@@ -4,7 +4,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import flab.eryuksa.todocompose.data.entity.Task
 
-@Database(entities = [Task::class], version = 1)
+@Database(entities = [Task::class], version = 2)
 abstract class TaskDatabase : RoomDatabase() {
 
     abstract fun getDao(): TaskDao

--- a/app/src/main/java/flab/eryuksa/todocompose/data/di/DatabaseModule.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/data/di/DatabaseModule.kt
@@ -24,7 +24,8 @@ object DatabaseModule {
             context,
             TaskDatabase::class.java,
             TASK_DATABASE_NAME
-        ).build()
+        ).fallbackToDestructiveMigration()
+            .build()
     }
 
     @Provides

--- a/app/src/main/java/flab/eryuksa/todocompose/data/di/RepositoryModule.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/data/di/RepositoryModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import flab.eryuksa.todocompose.data.repository.addtodo.AddTodoRepository
 import flab.eryuksa.todocompose.data.repository.DefaultTaskRepository
 import flab.eryuksa.todocompose.data.repository.deletetask.DeleteTaskRepository
+import flab.eryuksa.todocompose.data.repository.taskdetails.TaskDetailsRepository
 import flab.eryuksa.todocompose.data.repository.tasks.TasksRepository
 import javax.inject.Singleton
 
@@ -26,4 +27,7 @@ abstract class RepositoryModule {
     @Singleton
     abstract fun bindDeleteTaskRepository(deleteTaskRepository: DefaultTaskRepository): DeleteTaskRepository
 
+    @Binds
+    @Singleton
+    abstract fun bindTaskDetailsRepository(taskDetailsRepository: DefaultTaskRepository): TaskDetailsRepository
 }

--- a/app/src/main/java/flab/eryuksa/todocompose/data/entity/Task.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/data/entity/Task.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 @Entity(tableName = "task")
 data class Task(
     val title: String,
-    val details: String,
+    val memo: String,
     val isDone: Boolean,
     @PrimaryKey val id: String = UUID.randomUUID().toString()
 ) : Serializable

--- a/app/src/main/java/flab/eryuksa/todocompose/data/repository/DefaultTaskRepository.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/data/repository/DefaultTaskRepository.kt
@@ -38,7 +38,7 @@ class DefaultTaskRepository @Inject constructor(
         localDataSource.addTask(
             Task(
                 title = title,
-                details = details,
+                memo = details,
                 isDone = false
             )
         )

--- a/app/src/main/java/flab/eryuksa/todocompose/data/repository/DefaultTaskRepository.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/data/repository/DefaultTaskRepository.kt
@@ -3,6 +3,7 @@ package flab.eryuksa.todocompose.data.repository
 import flab.eryuksa.todocompose.data.entity.Task
 import flab.eryuksa.todocompose.data.repository.addtodo.AddTodoRepository
 import flab.eryuksa.todocompose.data.repository.deletetask.DeleteTaskRepository
+import flab.eryuksa.todocompose.data.repository.taskdetails.TaskDetailsRepository
 import flab.eryuksa.todocompose.data.repository.tasks.TasksRepository
 import flab.eryuksa.todocompose.data.source.local.LocalDataSource
 import kotlinx.coroutines.flow.Flow
@@ -11,7 +12,7 @@ import javax.inject.Inject
 
 class DefaultTaskRepository @Inject constructor(
     private val localDataSource: LocalDataSource
-) : TasksRepository, AddTodoRepository, DeleteTaskRepository {
+) : TasksRepository, AddTodoRepository, DeleteTaskRepository, TaskDetailsRepository {
 
     private val taskList: Flow<List<Task>> = localDataSource.getAllTaskStream()
 

--- a/app/src/main/java/flab/eryuksa/todocompose/data/repository/taskdetails/TaskDetailsRepository.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/data/repository/taskdetails/TaskDetailsRepository.kt
@@ -1,0 +1,8 @@
+package flab.eryuksa.todocompose.data.repository.taskdetails
+
+import flab.eryuksa.todocompose.data.entity.Task
+
+interface TaskDetailsRepository {
+
+    suspend fun updateTaskToModifiedTask(modifiedTask: Task)
+}

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/addtodo/ui/AddTodoDialog.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/addtodo/ui/AddTodoDialog.kt
@@ -29,7 +29,7 @@ import flab.eryuksa.todocompose.presentation.addtodo.viewmodel.input.AddTodoInpu
 import flab.eryuksa.todocompose.presentation.addtodo.viewmodel.output.AddTodoOutput
 import flab.eryuksa.todocompose.presentation.components.CancelAndConfirmButtons
 import flab.eryuksa.todocompose.presentation.theme.ADD_TODO_DIALOG_HEIGHT_FRACTION
-import flab.eryuksa.todocompose.presentation.theme.DIALOG_ROUNDED_CORNER_SIZE
+import flab.eryuksa.todocompose.presentation.theme.DIALOG_ROUNDED_CORNER_SIZE_DP
 import flab.eryuksa.todocompose.presentation.theme.Padding
 
 @Composable
@@ -41,7 +41,7 @@ fun AddTodoDialog(input: AddTodoInput, output: AddTodoOutput) {
     Dialog(input::dismissScreen) {
         Surface(
             modifier = Modifier.height(dialogHeightDp),
-            shape = RoundedCornerShape(size = DIALOG_ROUNDED_CORNER_SIZE.dp),
+            shape = RoundedCornerShape(size = DIALOG_ROUNDED_CORNER_SIZE_DP.dp),
             color = Color.White
         ) {
             Column(modifier = Modifier.padding(Padding.LARGE)) {

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/addtodo/ui/AddTodoDialog.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/addtodo/ui/AddTodoDialog.kt
@@ -45,8 +45,8 @@ fun AddTodoDialog(input: AddTodoInput, output: AddTodoOutput) {
             color = Color.White
         ) {
             Column(modifier = Modifier.padding(Padding.LARGE)) {
-                TitleTextField(uiState.title, input::updateTitle)
-                DetailsTextField(
+                AddTodoTitleTextField(uiState.title, input::updateTitle)
+                AddTodoMemoTextField(
                     text = uiState.details,
                     onTextChange = input::updateDetails,
                     modifier = Modifier.weight(weight = 1f)
@@ -64,7 +64,7 @@ fun AddTodoDialog(input: AddTodoInput, output: AddTodoOutput) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TitleTextField(text: String, onTextChange: (String) -> Unit) {
+fun AddTodoTitleTextField(text: String, onTextChange: (String) -> Unit) {
     TextField(
         value = text,
         onValueChange = onTextChange,
@@ -79,7 +79,7 @@ fun TitleTextField(text: String, onTextChange: (String) -> Unit) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DetailsTextField(
+fun AddTodoMemoTextField(
     text: String,
     onTextChange: (String) -> Unit,
     modifier: Modifier = Modifier
@@ -87,7 +87,7 @@ fun DetailsTextField(
     TextField(
         value = text,
         onValueChange = onTextChange,
-        placeholder = { Text(stringResource(R.string.details)) },
+        placeholder = { Text(stringResource(R.string.memo)) },
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = Padding.SMALL),
@@ -98,7 +98,7 @@ fun DetailsTextField(
 
 @Preview(heightDp = 720)
 @Composable
-fun AddTaskScreenPreview() {
+fun AddTodoScreenPreview() {
     Surface {
         val viewModel: AddTodoViewModel = viewModel()
         AddTodoDialog(viewModel, viewModel)

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/deletetask/DeleteTaskDialogFragment.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/deletetask/DeleteTaskDialogFragment.kt
@@ -10,9 +10,12 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
+import flab.eryuksa.todocompose.R
 import flab.eryuksa.todocompose.presentation.deletetask.ui.DeleteTaskDialog
 import flab.eryuksa.todocompose.presentation.deletetask.viewmodel.DeleteTaskViewModel
+import flab.eryuksa.todocompose.presentation.deletetask.viewmodel.output.DeleteTaskEffect
 import flab.eryuksa.todocompose.presentation.theme.ToDoComposeTheme
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -46,10 +49,16 @@ class DeleteTaskDialogFragment : DialogFragment() {
     }
 
     private fun observeUiEffect() {
+        val navController = findNavController()
+
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                viewModel.uiEffect.collectLatest {
-                    dismiss()
+                viewModel.uiEffect.collectLatest { effect ->
+                    when (effect) {
+                        is DeleteTaskEffect.DismissDeleteTaskScreen -> dismiss()
+                        is DeleteTaskEffect.GoBackToTasksScreen ->
+                            navController.popBackStack(R.id.tasksFragment, false)
+                    }
                 }
             }
         }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/deletetask/ui/DeleteTaskDialog.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/deletetask/ui/DeleteTaskDialog.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.window.Dialog
 import flab.eryuksa.todocompose.R
 import flab.eryuksa.todocompose.presentation.components.CancelAndConfirmButtons
 import flab.eryuksa.todocompose.presentation.theme.DELETE_TASK_DIALOG_WIDTH_FRACTION
-import flab.eryuksa.todocompose.presentation.theme.DIALOG_ROUNDED_CORNER_SIZE
+import flab.eryuksa.todocompose.presentation.theme.DIALOG_ROUNDED_CORNER_SIZE_DP
 import flab.eryuksa.todocompose.presentation.theme.Padding
 
 @Composable
@@ -33,7 +33,7 @@ fun DeleteTaskDialog(
     Dialog(onDismissRequest = onDismiss) {
         Surface(
             modifier = Modifier.width(dialogWidthDp),
-            shape = RoundedCornerShape(size = DIALOG_ROUNDED_CORNER_SIZE.dp),
+            shape = RoundedCornerShape(size = DIALOG_ROUNDED_CORNER_SIZE_DP.dp),
             color = Color.White
         ) {
             Column(modifier = Modifier.padding(Padding.LARGE)) {

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/deletetask/viewmodel/DeleteTaskViewModel.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/deletetask/viewmodel/DeleteTaskViewModel.kt
@@ -35,7 +35,7 @@ class DeleteTaskViewModel @Inject constructor(
     override fun deleteTask() {
         viewModelScope.launch {
             repository.deleteTask(task)
-            _uiEffect.emit(DeleteTaskEffect.DismissDeleteTaskScreen)
+            _uiEffect.emit(DeleteTaskEffect.GoBackToTasksScreen)
         }
     }
 

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/deletetask/viewmodel/output/DeleteTaskEffect.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/deletetask/viewmodel/output/DeleteTaskEffect.kt
@@ -3,4 +3,5 @@ package flab.eryuksa.todocompose.presentation.deletetask.viewmodel.output
 sealed interface DeleteTaskEffect {
 
     object DismissDeleteTaskScreen : DeleteTaskEffect
+    object GoBackToTasksScreen : DeleteTaskEffect
 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/TaskDetailsFragment.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/TaskDetailsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -37,11 +38,7 @@ class TaskDetailsFragment : Fragment() {
                 ToDoComposeTheme() {
                     TaskDetailsScreen(
                         taskDetailsState = viewModel.uiState,
-                        onClickBackButton = viewModel::goBack,
-                        onClickDeleteButton = viewModel::deleteTask,
-                        onClickCheckButton = viewModel::changeTaskDoneState,
-                        onTitleChange = viewModel::updateTitle,
-                        onMemoChange = viewModel::updateMemo
+                        input = viewModel
                     )
                 }
             }
@@ -51,6 +48,7 @@ class TaskDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         observeUiEffect()
+        addOnBackPressedCallback()
     }
 
     private fun observeUiEffect() {
@@ -60,7 +58,7 @@ class TaskDetailsFragment : Fragment() {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 viewModel.uiEffect.collectLatest { effect ->
                     when (effect) {
-                        is TaskDetailsEffect.GoBack -> navController.navigateUp()
+                        is TaskDetailsEffect.GoBackScreen -> navController.navigateUp()
                         is TaskDetailsEffect.ShowDeleteTaskDialog -> {
                             val bundle = bundleOf(
                                 DeleteTaskViewModel.TASK_TO_BE_DELETED_KEY to effect.taskToBeDeleted
@@ -70,6 +68,12 @@ class TaskDetailsFragment : Fragment() {
                     }
                 }
             }
+        }
+    }
+
+    private fun addOnBackPressedCallback() {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            viewModel.updateTaskAndGoToBackScreen()
         }
     }
 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/TaskDetailsFragment.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/TaskDetailsFragment.kt
@@ -1,4 +1,4 @@
-package flab.eryuksa.todocompose.presentation.tasks
+package flab.eryuksa.todocompose.presentation.details
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -15,18 +15,17 @@ import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import flab.eryuksa.todocompose.R
 import flab.eryuksa.todocompose.presentation.deletetask.viewmodel.DeleteTaskViewModel
+import flab.eryuksa.todocompose.presentation.details.ui.TaskDetailsScreen
 import flab.eryuksa.todocompose.presentation.details.viewmodel.TaskDetailsViewModel
-import flab.eryuksa.todocompose.presentation.tasks.ui.TasksScreen
-import flab.eryuksa.todocompose.presentation.tasks.viewmodel.TasksViewModel
-import flab.eryuksa.todocompose.presentation.tasks.viewmodel.output.TasksEffect
+import flab.eryuksa.todocompose.presentation.details.viewmodel.output.TaskDetailsEffect
 import flab.eryuksa.todocompose.presentation.theme.ToDoComposeTheme
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class TasksFragment : Fragment() {
+class TaskDetailsFragment : Fragment() {
 
-    private val viewModel: TasksViewModel by activityViewModels()
+    private val viewModel: TaskDetailsViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -35,10 +34,14 @@ class TasksFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                ToDoComposeTheme {
-                    TasksScreen(
-                        input = viewModel,
-                        output = viewModel
+                ToDoComposeTheme() {
+                    TaskDetailsScreen(
+                        taskDetailsState = viewModel.uiState,
+                        onClickBackButton = viewModel::goBack,
+                        onClickDeleteButton = viewModel::deleteTask,
+                        onClickCheckButton = viewModel::changeTaskDoneState,
+                        onTitleChange = viewModel::updateTitle,
+                        onMemoChange = viewModel::updateMemo
                     )
                 }
             }
@@ -57,19 +60,12 @@ class TasksFragment : Fragment() {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 viewModel.uiEffect.collectLatest { effect ->
                     when (effect) {
-                        is TasksEffect.ShowAddTodoScreen ->
-                            navController.navigate(R.id.actionTasksToAddTodo)
-                        is TasksEffect.ShowDeleteTaskDialog -> {
+                        is TaskDetailsEffect.GoBack -> navController.navigateUp()
+                        is TaskDetailsEffect.ShowDeleteTaskDialog -> {
                             val bundle = bundleOf(
                                 DeleteTaskViewModel.TASK_TO_BE_DELETED_KEY to effect.taskToBeDeleted
                             )
-                            navController.navigate(R.id.actionTasksToDeleteTask, bundle)
-                        }
-                        is TasksEffect.ShowTaskDetailsScreen -> {
-                            val bundle = bundleOf(
-                                TaskDetailsViewModel.TASK_DETAILS_TASK_KEY to effect.task
-                            )
-                            navController.navigate(R.id.actionTasksToTaskDetails, bundle)
+                            navController.navigate(R.id.actionTaskDetailsToDeleteTask, bundle)
                         }
                     }
                 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/ui/TaskDetailsScreen.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/ui/TaskDetailsScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -28,23 +30,28 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import flab.eryuksa.todocompose.R
 import flab.eryuksa.todocompose.data.entity.Task
+import flab.eryuksa.todocompose.presentation.details.viewmodel.output.TaskDetailsState
 import flab.eryuksa.todocompose.presentation.theme.Padding
 import flab.eryuksa.todocompose.presentation.theme.ToDoComposeTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TaskDetailsScreen(
-    task: Task,
+    taskDetailsState: StateFlow<TaskDetailsState>,
     onClickBackButton: () -> Unit,
-    onClickDeleteButton: (task: Task) -> Unit,
-    onClickCheckButton: (task: Task) -> Unit,
-    onTitleChange: (title: String) -> Unit,
-    onMemoChange: (memo: String) -> Unit
+    onClickDeleteButton: () -> Unit,
+    onClickCheckButton: () -> Unit,
+    onTitleChange: (newTitle: String) -> Unit,
+    onMemoChange: (newMemo: String) -> Unit
 ) {
+    val uiState by taskDetailsState.collectAsState()
+
     Scaffold(
         topBar = {
             TaskDetailsAppBar(
-                task = task,
+                task = uiState.task,
                 onClickBackButton = onClickBackButton,
                 onClickDeleteButton = onClickDeleteButton,
                 onClickCheckButton = onClickCheckButton
@@ -56,19 +63,21 @@ fun TaskDetailsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(
-                    top = paddingValue.calculateTopPadding().plus(Padding.LARGE),
+                    top = paddingValue
+                        .calculateTopPadding()
+                        .plus(Padding.LARGE),
                     start = Padding.LARGE,
                     end = Padding.LARGE,
                     bottom = Padding.LARGE
                 )
         ) {
             TaskDetailsTitleTextField(
-                title = task.title,
+                title = uiState.task.title,
                 onTitleChange = onTitleChange
             )
             Spacer(modifier = Modifier.height(Padding.LARGE))
             TaskDetailsMemoTextField(
-                memo = task.memo,
+                memo = uiState.task.memo,
                 onMemoChange = onMemoChange
             )
         }
@@ -80,8 +89,8 @@ fun TaskDetailsScreen(
 fun TaskDetailsAppBar(
     task: Task,
     onClickBackButton: () -> Unit,
-    onClickDeleteButton: (task: Task) -> Unit,
-    onClickCheckButton: (task: Task) -> Unit
+    onClickDeleteButton: () -> Unit,
+    onClickCheckButton: () -> Unit
 ) {
     TopAppBar(
         title = {},
@@ -100,13 +109,13 @@ fun TaskDetailsAppBar(
             }
         },
         actions = {
-            IconButton(onClick = { onClickDeleteButton(task) }) {
+            IconButton(onClick = onClickDeleteButton) {
                 Icon(
                     imageVector = Icons.Rounded.Delete,
                     contentDescription = stringResource(R.string.back_button_description)
                 )
             }
-            IconButton(onClick = { onClickCheckButton(task) }) {
+            IconButton(onClick = onClickCheckButton) {
                 Icon(
                     painter = if (task.isDone) {
                         painterResource(R.drawable.checked_circle_24dp)
@@ -167,7 +176,9 @@ fun TasksDetailsAppBarPreview() {
 fun TasksDetailsScreenPreview() {
     ToDoComposeTheme {
         TaskDetailsScreen(
-            task = Task("할 일 제목", "할 일 메모", isDone = true),
+            taskDetailsState = MutableStateFlow(
+                TaskDetailsState(Task("할 일 제목", "할 일 메모", isDone = true))
+            ),
             onClickBackButton = {},
             onClickDeleteButton = {},
             onClickCheckButton = {},

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/ui/TaskDetailsScreen.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/ui/TaskDetailsScreen.kt
@@ -1,13 +1,14 @@
 package flab.eryuksa.todocompose.presentation.details.ui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Delete
@@ -18,33 +19,36 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import flab.eryuksa.todocompose.R
 import flab.eryuksa.todocompose.data.entity.Task
+import flab.eryuksa.todocompose.presentation.details.viewmodel.TaskDetailsViewModel
+import flab.eryuksa.todocompose.presentation.details.viewmodel.input.TaskDetailsInput
 import flab.eryuksa.todocompose.presentation.details.viewmodel.output.TaskDetailsState
 import flab.eryuksa.todocompose.presentation.theme.Padding
+import flab.eryuksa.todocompose.presentation.theme.TASK_DETAILS_MEMO_MIN_HEIGHT_DP
+import flab.eryuksa.todocompose.presentation.theme.TASK_DETAILS_ROUNDED_CORNER_SIZE_DP
 import flab.eryuksa.todocompose.presentation.theme.ToDoComposeTheme
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TaskDetailsScreen(
     taskDetailsState: StateFlow<TaskDetailsState>,
-    onClickBackButton: () -> Unit,
-    onClickDeleteButton: () -> Unit,
-    onClickCheckButton: () -> Unit,
-    onTitleChange: (newTitle: String) -> Unit,
-    onMemoChange: (newMemo: String) -> Unit
+    input: TaskDetailsInput
 ) {
     val uiState by taskDetailsState.collectAsState()
 
@@ -52,9 +56,9 @@ fun TaskDetailsScreen(
         topBar = {
             TaskDetailsAppBar(
                 task = uiState.task,
-                onClickBackButton = onClickBackButton,
-                onClickDeleteButton = onClickDeleteButton,
-                onClickCheckButton = onClickCheckButton
+                onClickBackButton = input::updateTaskAndGoToBackScreen,
+                onClickDeleteButton = input::showDeleteTaskDialog,
+                onClickCheckButton = input::changeTaskDoneState
             )
         },
         modifier = Modifier.fillMaxSize()
@@ -65,7 +69,7 @@ fun TaskDetailsScreen(
                 .padding(
                     top = paddingValue
                         .calculateTopPadding()
-                        .plus(Padding.LARGE),
+                        .plus(Padding.XLARGE),
                     start = Padding.LARGE,
                     end = Padding.LARGE,
                     bottom = Padding.LARGE
@@ -73,12 +77,12 @@ fun TaskDetailsScreen(
         ) {
             TaskDetailsTitleTextField(
                 title = uiState.task.title,
-                onTitleChange = onTitleChange
+                onTitleChange = input::updateTitle
             )
             Spacer(modifier = Modifier.height(Padding.LARGE))
             TaskDetailsMemoTextField(
                 memo = uiState.task.memo,
-                onMemoChange = onMemoChange
+                onMemoChange = input::updateMemo
             )
         }
     }
@@ -93,13 +97,13 @@ fun TaskDetailsAppBar(
     onClickCheckButton: () -> Unit
 ) {
     TopAppBar(
-        title = {},
+        title = { TaskDetailsAppBarTitle(isTaskDone = task.isDone) },
         colors = TopAppBarDefaults.smallTopAppBarColors(
             containerColor = MaterialTheme.colorScheme.primary,
             navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
-            actionIconContentColor = MaterialTheme.colorScheme.onPrimary
+            actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+            titleContentColor = MaterialTheme.colorScheme.onPrimary
         ),
-
         navigationIcon = {
             IconButton(onClick = onClickBackButton) {
                 Icon(
@@ -112,50 +116,86 @@ fun TaskDetailsAppBar(
             IconButton(onClick = onClickDeleteButton) {
                 Icon(
                     imageVector = Icons.Rounded.Delete,
-                    contentDescription = stringResource(R.string.back_button_description)
+                    contentDescription = stringResource(R.string.delete_task_button_description)
                 )
             }
             IconButton(onClick = onClickCheckButton) {
                 Icon(
                     painter = if (task.isDone) {
-                        painterResource(R.drawable.checked_circle_24dp)
+                        painterResource(id = R.drawable.check_box_24dp)
                     } else {
-                        painterResource(R.drawable.button_unchecked_24dp)
+                        painterResource(id = R.drawable.check_box_outline_blank_24dp)
                     },
-                    contentDescription = stringResource(R.string.back_button_description)
+                    contentDescription = if (task.isDone) {
+                        stringResource(id = R.string.make_task_todo)
+                    } else {
+                        stringResource(id = R.string.make_task_done)
+                    }
                 )
             }
         },
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TaskDetailsTitleTextField(title: String, onTitleChange: (title: String) -> Unit) {
-    TextField(
-        value = title,
-        onValueChange = onTitleChange,
-        placeholder = { Text(stringResource(R.string.title)) },
-        modifier = Modifier
-            .wrapContentHeight()
-            .fillMaxWidth(),
-        maxLines = 2,
-        textStyle = MaterialTheme.typography.titleMedium
+fun TaskDetailsAppBarTitle(isTaskDone: Boolean) {
+    Text(
+        text = if (isTaskDone) {
+            stringResource(R.string.done_task)
+        } else {
+            stringResource(R.string.todo_task)
+        }
     )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ColumnScope.TaskDetailsMemoTextField(memo: String, onMemoChange: (memo: String) -> Unit) {
+fun TaskDetailsTitleTextField(title: String, onTitleChange: (newTitle: String) -> Unit) {
     TextField(
-        value = memo,
-        onValueChange = onMemoChange,
-        placeholder = { Text(stringResource(R.string.memo)) },
+        value = title,
+        onValueChange = onTitleChange,
         modifier = Modifier
-            .weight(1f)
+            .wrapContentHeight()
             .fillMaxWidth(),
-        textStyle = MaterialTheme.typography.bodyMedium.copy(textAlign = TextAlign.Start)
+        placeholder = { Text(stringResource(R.string.title)) },
+        maxLines = 2,
+        textStyle = MaterialTheme.typography.titleMedium,
+        shape = RoundedCornerShape(size = TASK_DETAILS_ROUNDED_CORNER_SIZE_DP.dp),
+        colors = TextFieldDefaults.textFieldColors(
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent
+        )
     )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TaskDetailsMemoTextField(memo: String, onMemoChange: (memo: String) -> Unit) {
+    Column(modifier = Modifier.padding(bottom = Padding.LARGE)) {
+        Text(
+            text = stringResource(R.string.memo),
+            modifier = Modifier.padding(
+                top = Padding.MEDIUM,
+                bottom = Padding.LARGE
+            ),
+            style = MaterialTheme.typography.bodyLarge
+        )
+        TextField(
+            value = memo,
+            onValueChange = onMemoChange,
+            modifier = Modifier
+                .fillMaxWidth()
+                .defaultMinSize(minHeight = TASK_DETAILS_MEMO_MIN_HEIGHT_DP.dp),
+            textStyle = MaterialTheme.typography.bodyMedium.copy(textAlign = TextAlign.Start),
+            shape = RoundedCornerShape(size = TASK_DETAILS_ROUNDED_CORNER_SIZE_DP.dp),
+            colors = TextFieldDefaults.textFieldColors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                disabledIndicatorColor = Color.Transparent
+            )
+        )
+    }
 }
 
 @Preview
@@ -174,16 +214,11 @@ fun TasksDetailsAppBarPreview() {
 @Preview(heightDp = 480)
 @Composable
 fun TasksDetailsScreenPreview() {
+    val viewModel: TaskDetailsViewModel = viewModel()
     ToDoComposeTheme {
         TaskDetailsScreen(
-            taskDetailsState = MutableStateFlow(
-                TaskDetailsState(Task("할 일 제목", "할 일 메모", isDone = true))
-            ),
-            onClickBackButton = {},
-            onClickDeleteButton = {},
-            onClickCheckButton = {},
-            onTitleChange = {},
-            onMemoChange = {}
+            taskDetailsState = viewModel.uiState,
+            input = viewModel
         )
     }
 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/ui/TaskDetailsScreen.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/ui/TaskDetailsScreen.kt
@@ -1,0 +1,178 @@
+package flab.eryuksa.todocompose.presentation.details.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import flab.eryuksa.todocompose.R
+import flab.eryuksa.todocompose.data.entity.Task
+import flab.eryuksa.todocompose.presentation.theme.Padding
+import flab.eryuksa.todocompose.presentation.theme.ToDoComposeTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TaskDetailsScreen(
+    task: Task,
+    onClickBackButton: () -> Unit,
+    onClickDeleteButton: (task: Task) -> Unit,
+    onClickCheckButton: (task: Task) -> Unit,
+    onTitleChange: (title: String) -> Unit,
+    onMemoChange: (memo: String) -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TaskDetailsAppBar(
+                task = task,
+                onClickBackButton = onClickBackButton,
+                onClickDeleteButton = onClickDeleteButton,
+                onClickCheckButton = onClickCheckButton
+            )
+        },
+        modifier = Modifier.fillMaxSize()
+    ) { paddingValue ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    top = paddingValue.calculateTopPadding().plus(Padding.LARGE),
+                    start = Padding.LARGE,
+                    end = Padding.LARGE,
+                    bottom = Padding.LARGE
+                )
+        ) {
+            TaskDetailsTitleTextField(
+                title = task.title,
+                onTitleChange = onTitleChange
+            )
+            Spacer(modifier = Modifier.height(Padding.LARGE))
+            TaskDetailsMemoTextField(
+                memo = task.memo,
+                onMemoChange = onMemoChange
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TaskDetailsAppBar(
+    task: Task,
+    onClickBackButton: () -> Unit,
+    onClickDeleteButton: (task: Task) -> Unit,
+    onClickCheckButton: (task: Task) -> Unit
+) {
+    TopAppBar(
+        title = {},
+        colors = TopAppBarDefaults.smallTopAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+            actionIconContentColor = MaterialTheme.colorScheme.onPrimary
+        ),
+
+        navigationIcon = {
+            IconButton(onClick = onClickBackButton) {
+                Icon(
+                    imageVector = Icons.Rounded.ArrowBack,
+                    contentDescription = stringResource(R.string.back_button_description)
+                )
+            }
+        },
+        actions = {
+            IconButton(onClick = { onClickDeleteButton(task) }) {
+                Icon(
+                    imageVector = Icons.Rounded.Delete,
+                    contentDescription = stringResource(R.string.back_button_description)
+                )
+            }
+            IconButton(onClick = { onClickCheckButton(task) }) {
+                Icon(
+                    painter = if (task.isDone) {
+                        painterResource(R.drawable.checked_circle_24dp)
+                    } else {
+                        painterResource(R.drawable.button_unchecked_24dp)
+                    },
+                    contentDescription = stringResource(R.string.back_button_description)
+                )
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TaskDetailsTitleTextField(title: String, onTitleChange: (title: String) -> Unit) {
+    TextField(
+        value = title,
+        onValueChange = onTitleChange,
+        placeholder = { Text(stringResource(R.string.title)) },
+        modifier = Modifier
+            .wrapContentHeight()
+            .fillMaxWidth(),
+        maxLines = 2,
+        textStyle = MaterialTheme.typography.titleMedium
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ColumnScope.TaskDetailsMemoTextField(memo: String, onMemoChange: (memo: String) -> Unit) {
+    TextField(
+        value = memo,
+        onValueChange = onMemoChange,
+        placeholder = { Text(stringResource(R.string.memo)) },
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxWidth(),
+        textStyle = MaterialTheme.typography.bodyMedium.copy(textAlign = TextAlign.Start)
+    )
+}
+
+@Preview
+@Composable
+fun TasksDetailsAppBarPreview() {
+    ToDoComposeTheme {
+        TaskDetailsAppBar(
+            task = Task("할 일 제목", "할 일 메모", isDone = true),
+            onClickBackButton = { },
+            onClickDeleteButton = {},
+            onClickCheckButton = {}
+        )
+    }
+}
+
+@Preview(heightDp = 480)
+@Composable
+fun TasksDetailsScreenPreview() {
+    ToDoComposeTheme {
+        TaskDetailsScreen(
+            task = Task("할 일 제목", "할 일 메모", isDone = true),
+            onClickBackButton = {},
+            onClickDeleteButton = {},
+            onClickCheckButton = {},
+            onTitleChange = {},
+            onMemoChange = {}
+        )
+    }
+}

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/TaskDetailsViewModel.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/TaskDetailsViewModel.kt
@@ -1,0 +1,63 @@
+package flab.eryuksa.todocompose.presentation.details.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import flab.eryuksa.todocompose.data.entity.Task
+import flab.eryuksa.todocompose.presentation.details.viewmodel.input.TaskDetailsInput
+import flab.eryuksa.todocompose.presentation.details.viewmodel.output.TaskDetailsEffect
+import flab.eryuksa.todocompose.presentation.details.viewmodel.output.TaskDetailsOutput
+import flab.eryuksa.todocompose.presentation.details.viewmodel.output.TaskDetailsState
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TaskDetailsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel(), TaskDetailsInput, TaskDetailsOutput {
+
+    private val _uiState = MutableStateFlow(
+        TaskDetailsState(savedStateHandle.get<Task>(TASK_DETAILS_TASK_KEY)!!)
+    )
+    override val uiState: StateFlow<TaskDetailsState>
+        get() = _uiState
+
+    private val _uiEffect = MutableSharedFlow<TaskDetailsEffect>(replay = 0)
+    override val uiEffect: SharedFlow<TaskDetailsEffect>
+        get() = _uiEffect
+
+    override fun goBack() {
+        viewModelScope.launch {
+            _uiEffect.emit(TaskDetailsEffect.GoBack)
+        }
+    }
+
+    override fun deleteTask() {
+    }
+
+    override fun changeTaskDoneState() {
+        val task = _uiState.value.task
+        _uiState.value = TaskDetailsState(
+            task.copy(isDone = task.isDone.not())
+        )
+    }
+
+    override fun updateTitle(newTitle: String) {
+        val updatedTask = _uiState.value.task.copy(title = newTitle)
+        _uiState.value = TaskDetailsState(updatedTask)
+    }
+
+    override fun updateMemo(newMemo: String) {
+        val updatedTask = _uiState.value.task.copy(memo = newMemo)
+        _uiState.value = TaskDetailsState(updatedTask)
+    }
+
+    companion object {
+        const val TASK_DETAILS_TASK_KEY = "TASK_DETAILS_TASK"
+    }
+}

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/input/TaskDetailsInput.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/input/TaskDetailsInput.kt
@@ -2,8 +2,8 @@ package flab.eryuksa.todocompose.presentation.details.viewmodel.input
 
 interface TaskDetailsInput {
 
-    fun goBack()
-    fun deleteTask()
+    fun updateTaskAndGoToBackScreen()
+    fun showDeleteTaskDialog()
     fun changeTaskDoneState()
     fun updateTitle(newTitle: String)
     fun updateMemo(newMemo: String)

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/input/TaskDetailsInput.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/input/TaskDetailsInput.kt
@@ -1,0 +1,10 @@
+package flab.eryuksa.todocompose.presentation.details.viewmodel.input
+
+interface TaskDetailsInput {
+
+    fun goBack()
+    fun deleteTask()
+    fun changeTaskDoneState()
+    fun updateTitle(newTitle: String)
+    fun updateMemo(newMemo: String)
+}

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/output/TaskDetailsEffect.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/output/TaskDetailsEffect.kt
@@ -1,0 +1,9 @@
+package flab.eryuksa.todocompose.presentation.details.viewmodel.output
+
+import flab.eryuksa.todocompose.data.entity.Task
+
+sealed interface TaskDetailsEffect {
+
+    object GoBack : TaskDetailsEffect
+    data class ShowDeleteTaskDialog(val taskToBeDeleted: Task) : TaskDetailsEffect
+}

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/output/TaskDetailsEffect.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/output/TaskDetailsEffect.kt
@@ -4,6 +4,6 @@ import flab.eryuksa.todocompose.data.entity.Task
 
 sealed interface TaskDetailsEffect {
 
-    object GoBack : TaskDetailsEffect
+    object GoBackScreen : TaskDetailsEffect
     data class ShowDeleteTaskDialog(val taskToBeDeleted: Task) : TaskDetailsEffect
 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/output/TaskDetailsOutput.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/output/TaskDetailsOutput.kt
@@ -1,0 +1,10 @@
+package flab.eryuksa.todocompose.presentation.details.viewmodel.output
+
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+interface TaskDetailsOutput {
+
+    val uiState: StateFlow<TaskDetailsState>
+    val uiEffect: SharedFlow<TaskDetailsEffect>
+}

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/output/TaskDetailsState.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/details/viewmodel/output/TaskDetailsState.kt
@@ -1,0 +1,5 @@
+package flab.eryuksa.todocompose.presentation.details.viewmodel.output
+
+import flab.eryuksa.todocompose.data.entity.Task
+
+data class TaskDetailsState(val task: Task)

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/TasksFragment.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/TasksFragment.kt
@@ -57,12 +57,12 @@ class TasksFragment : Fragment() {
                 viewModel.uiEffect.collectLatest { effect ->
                     when (effect) {
                         is TasksEffect.ShowAddTodoScreen ->
-                            navController.navigate(R.id.actionTasksToAddTodoDialog)
+                            navController.navigate(R.id.actionTasksToAddTodo)
                         is TasksEffect.ShowDeleteTaskScreen -> {
                             val bundle = bundleOf(
                                 DeleteTaskViewModel.TASK_TO_BE_DELETED_KEY to effect.taskToBeDeleted
                             )
-                            navController.navigate(R.id.actionTasksToDeleteTaskDialog, bundle)
+                            navController.navigate(R.id.actionTasksToDeleteTask, bundle)
                         }
                     }
                 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/ui/TasksScreen.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/ui/TasksScreen.kt
@@ -1,6 +1,7 @@
 package flab.eryuksa.todocompose.presentation.tasks.ui
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -68,11 +69,13 @@ fun TasksScreen(input: TasksInput, output: TasksOutput) {
         ) {
             TodoList(
                 todoList = uiState.todoList,
+                onClickTaskItem = input::showTaskDetailsScreen,
                 onTaskCheckedChange = input::changeCheckedState,
                 onClickDeleteTask = input::showDeleteTaskDialog
             )
             DoneList(
                 doneList = uiState.doneList,
+                onClickTaskItem = input::showTaskDetailsScreen,
                 onTaskCheckedChange = input::changeCheckedState,
                 onClickDeleteTask = input::showDeleteTaskDialog
             )
@@ -83,6 +86,7 @@ fun TasksScreen(input: TasksInput, output: TasksOutput) {
 @Composable
 fun TaskItem(
     task: Task,
+    onClickTaskItem: (Task) -> Unit,
     onTaskCheckedChange: (Task) -> Unit,
     onClickDeleteTask: (Task) -> Unit
 ) {
@@ -94,6 +98,7 @@ fun TaskItem(
                 horizontal = Padding.MEDIUM,
                 vertical = Padding.MEDIUM
             )
+            .clickable(onClick = { onClickTaskItem(task) })
     ) {
         Checkbox(
             checked = task.isDone,
@@ -124,6 +129,7 @@ fun DeleteTaskButton(onClick: () -> Unit) {
 @Composable
 fun TodoList(
     todoList: List<Task>,
+    onClickTaskItem: (Task) -> Unit,
     onTaskCheckedChange: (Task) -> Unit,
     onClickDeleteTask: (Task) -> Unit
 ) {
@@ -131,6 +137,7 @@ fun TodoList(
         TaskList(
             categoryTitle = stringResource(R.string.todo_task),
             taskList = todoList,
+            onClickTaskItem = onClickTaskItem,
             onTaskCheckedChange = onTaskCheckedChange,
             onClickDeleteTask = onClickDeleteTask
         )
@@ -141,6 +148,7 @@ fun TodoList(
 @Composable
 fun DoneList(
     doneList: List<Task>,
+    onClickTaskItem: (Task) -> Unit,
     onTaskCheckedChange: (Task) -> Unit,
     onClickDeleteTask: (Task) -> Unit
 ) {
@@ -148,6 +156,7 @@ fun DoneList(
         TaskList(
             categoryTitle = stringResource(R.string.done_task),
             taskList = doneList,
+            onClickTaskItem = onClickTaskItem,
             onTaskCheckedChange = onTaskCheckedChange,
             onClickDeleteTask = onClickDeleteTask
         )
@@ -158,6 +167,7 @@ fun DoneList(
 fun TaskList(
     categoryTitle: String,
     taskList: List<Task>,
+    onClickTaskItem: (Task) -> Unit,
     onTaskCheckedChange: (Task) -> Unit,
     onClickDeleteTask: (Task) -> Unit
 ) {
@@ -170,6 +180,7 @@ fun TaskList(
             items(taskList) { task ->
                 TaskItem(
                     task = task,
+                    onClickTaskItem = onClickTaskItem,
                     onTaskCheckedChange = onTaskCheckedChange,
                     onClickDeleteTask = onClickDeleteTask
                 )
@@ -210,6 +221,7 @@ fun TaskComposablePreview() {
         ) {
             TaskItem(
                 task = Task("할일", "설명", true),
+                onClickTaskItem = {},
                 onTaskCheckedChange = {},
                 onClickDeleteTask = {}
             )
@@ -230,6 +242,7 @@ fun TaskListPreview() {
                     Task("할일1", "", false),
                     Task("할일2", "", false)
                 ),
+                onClickTaskItem = {},
                 onTaskCheckedChange = {},
                 onClickDeleteTask = {}
             )

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/viewmodel/TasksViewModel.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/viewmodel/TasksViewModel.kt
@@ -10,7 +10,6 @@ import flab.eryuksa.todocompose.presentation.tasks.viewmodel.output.TasksEffect
 import flab.eryuksa.todocompose.presentation.tasks.viewmodel.output.TasksOutput
 import flab.eryuksa.todocompose.presentation.tasks.viewmodel.output.TasksState
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -54,7 +53,13 @@ class TasksViewModel @Inject constructor(
 
     override fun showDeleteTaskDialog(task: Task) {
         viewModelScope.launch {
-            _uiEffect.emit(TasksEffect.ShowDeleteTaskScreen(taskToBeDeleted = task))
+            _uiEffect.emit(TasksEffect.ShowDeleteTaskDialog(taskToBeDeleted = task))
+        }
+    }
+
+    override fun showTaskDetailsScreen(task: Task) {
+        viewModelScope.launch {
+            _uiEffect.emit(TasksEffect.ShowTaskDetailsScreen(task))
         }
     }
 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/viewmodel/input/TasksInput.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/viewmodel/input/TasksInput.kt
@@ -7,4 +7,5 @@ interface TasksInput {
     fun showAddTaskScreen()
     fun changeCheckedState(task: Task)
     fun showDeleteTaskDialog(task: Task)
+    fun showTaskDetailsScreen(task: Task)
 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/viewmodel/output/TasksEffect.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/tasks/viewmodel/output/TasksEffect.kt
@@ -5,5 +5,6 @@ import flab.eryuksa.todocompose.data.entity.Task
 sealed interface TasksEffect {
 
     object ShowAddTodoScreen : TasksEffect
-    data class ShowDeleteTaskScreen(val taskToBeDeleted: Task) : TasksEffect
+    data class ShowDeleteTaskDialog(val taskToBeDeleted: Task) : TasksEffect
+    data class ShowTaskDetailsScreen(val task: Task) : TasksEffect
 }

--- a/app/src/main/java/flab/eryuksa/todocompose/presentation/theme/Constants.kt
+++ b/app/src/main/java/flab/eryuksa/todocompose/presentation/theme/Constants.kt
@@ -1,10 +1,14 @@
 package flab.eryuksa.todocompose.presentation.theme
 
 // Common
-const val DIALOG_ROUNDED_CORNER_SIZE = 16
+const val DIALOG_ROUNDED_CORNER_SIZE_DP = 16
 
 // AddTodo
 const val ADD_TODO_DIALOG_HEIGHT_FRACTION = 0.5
 
 // DeleteTask
 const val DELETE_TASK_DIALOG_WIDTH_FRACTION = 0.75
+
+// TaskDetails
+const val TASK_DETAILS_ROUNDED_CORNER_SIZE_DP = 4
+const val TASK_DETAILS_MEMO_MIN_HEIGHT_DP = 200

--- a/app/src/main/res/drawable/button_unchecked_24dp.xml
+++ b/app/src/main/res/drawable/button_unchecked_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/drawable/check_box_24dp.xml
+++ b/app/src/main/res/drawable/check_box_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.11,0 2,-0.9 2,-2L21,5c0,-1.1 -0.89,-2 -2,-2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/app/src/main/res/drawable/check_box_outline_blank_24dp.xml
+++ b/app/src/main/res/drawable/check_box_outline_blank_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,5v14H5V5h14m0,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/drawable/checked_circle_24dp.xml
+++ b/app/src/main/res/drawable/checked_circle_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -10,12 +10,16 @@
         android:label="TasksFragment" >
 
         <action
-            android:id="@+id/actionTasksToAddTodoDialog"
+            android:id="@+id/actionTasksToAddTodo"
             app:destination="@id/addTodoDialogFragment" />
 
         <action
-            android:id="@+id/actionTasksToDeleteTaskDialog"
+            android:id="@+id/actionTasksToDeleteTask"
             app:destination="@id/deleteTaskDialogFragment" />
+
+        <action
+            android:id="@+id/actionTasksToTaskDetails"
+            app:destination="@id/taskDetailsFragment" />
     </fragment>
 
     <dialog
@@ -32,4 +36,18 @@
             android:name="taskToBeDeleted"
             app:argType="flab.eryuksa.todocompose.data.entity.Task" />
     </dialog>
+
+    <fragment
+        android:id="@+id/taskDetailsFragment"
+        android:name="flab.eryuksa.todocompose.presentation.details.TaskDetailsFragment"
+        android:label="TaskDetailsFragment" >
+
+        <argument
+            android:name="taskForDetails"
+            app:argType="flab.eryuksa.todocompose.data.entity.Task" />
+
+        <action
+            android:id="@+id/actionTaskDetailsToDeleteTask"
+            app:destination="@id/deleteTaskDialogFragment" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,9 @@
     <!--Common-->
     <string name="yes">네</string>
     <string name="no">아니요</string>
+    <string name="back_button_description">뒤로 가기</string>
+    <string name="title">제목</string>
+    <string name="memo">메모</string>
 
     <!--TasksScreen-->
     <string name="add_task_please">오늘 할 일은 무엇인가요?</string>
@@ -15,8 +18,9 @@
     <string name="delete_task_dialog_contents_text">\'%s\'를 삭제하시겠어요?</string>
 
     <!--AddTodoScreen-->
-    <string name="title">제목</string>
-    <string name="details">세부 사항</string>
     <string name="cancel">취소</string>
     <string name="add">추가</string>
+
+    <!--TaskDetails-->
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="back_button_description">뒤로 가기</string>
     <string name="title">제목</string>
     <string name="memo">메모</string>
+    <string name="save">저장</string>
 
     <!--TasksScreen-->
     <string name="add_task_please">오늘 할 일은 무엇인가요?</string>
@@ -22,5 +23,6 @@
     <string name="add">추가</string>
 
     <!--TaskDetails-->
-
+    <string name="make_task_done">할 일을 끝낸 일 상태로 변경</string>
+    <string name="make_task_todo">끝낸 일을 할 일 상태로 변경</string>
 </resources>


### PR DESCRIPTION
- 상세 화면 기능: (1) 제목 및 메모 수정, (2) Task 삭제, (3) 할일<->끝낸 일 상태 변경

- Task 삭제 기능 구현하면서 해결했던 문제
DeleteTaskDialogFragment는 TasksFragment와 TaskDetailsFragment가 공통으로 띄우는 다이얼로그이다.

TasksFragment에서는 Task 삭제시 DeleteTaskDialogFragment을 dismiss()하기만 하면 삭제 내역이 화면에 바로 반영되었다. 왜냐면 ViewModel이 Room에서 흐르는 Flow를 관찰하고 있기 때문이다.
하지만 TaskDetailsFragment는 TasksFragment로 부터 Task를 직접 전달 받기 때문에 Task를 삭제하고 나서 DeleteTaskDialogFragment를 dismiss하더라도 TaskDetailsFragment 화면에 자동으로 반영되어 뒤로 가는 기능이 존재하지 않았다.  

그래서 Fragment간 통신으로 Task 삭제시 TaskDetailsFragment에 알려야 하나 고민했지만 TasksFragment와 TaskDetailsFragment가 DeleteTaskDialogFragment를 공유하고 있기 때문에 번거로울 수도 있다는 느낌이 들었다. 그래서 고민 끝에 UiEffect와 Navigation Controller를 활용해서 간결하게 해결했다.

DeleteTaskDialogFragment의 UiEffect에 DimissDeleteTaskDialog와 GoBackToTasksScreen 타입 두 가지를 만들었다.
그리고 어떤 화면에서든 DeleteTaskDialogFragment를 띄워서 Task를 삭제할 경우, DeleteTaskDialogFragment의 ViewModel에서 GoBackToTasksScreen effect를 방출하여 navController를 통해 TasksFragment로 되돌아가고, 삭제 작업을 취소할 경우에는 GoBackToTasksScreen를 방출하여 다이얼로그만 dismiss 하도록 했다.

그 결과 TaskDetailsFragment에서 Task를 삭제하면 DeleteTaskDialogFragment가 dimiss 되면서 TaskDetailsFragment에서 TasksFragment으로 화면이 되돌아간다.